### PR TITLE
Handle Capybara.default_wait_time deprecation

### DIFF
--- a/lib/transactional_capybara/ajax_helpers.rb
+++ b/lib/transactional_capybara/ajax_helpers.rb
@@ -24,7 +24,7 @@ module TransactionalCapybara
       end
 
       # TODO: timeout each individual session
-      def wait_until(timeout=Capybara.default_wait_time)
+      def wait_until(timeout=default_timeout)
         Timeout.timeout(timeout) do
           until yield
             sleep(0.01)
@@ -39,6 +39,16 @@ module TransactionalCapybara
       # Hack into Capybara's private interface to get access to all sessions
       def capybara_sessions
         Capybara.send :session_pool
+      end
+
+      # Handle Capybara.default_wait_time deprecation
+      # https://github.com/jnicklas/capybara/pull/1502
+      def default_timeout
+        @default_timeout ||= begin
+          Capybara.respond_to?(:default_max_wait_time) ?
+            Capybara.default_max_wait_time :
+            Capybara.default_wait_time
+        end
       end
 
       # Another hack, to see if Capybara sessions have been used

--- a/spec/ajax_spec.rb
+++ b/spec/ajax_spec.rb
@@ -104,4 +104,18 @@ RSpec.describe "server with AJAX", type: :feature, js: true do
       expect(find(".message").text).to eq(@expected_message)
     end
   end
+
+  it "uses Capybara.default_max_wait_time if available" do
+    allow(Capybara).to receive(:default_max_wait_time).and_return(5)
+    expect(Capybara).to receive(:default_max_wait_time).at_least(:once)
+
+    TransactionalCapybara::AjaxHelpers.wait_for_ajax(page)
+  end
+
+  it "fallbacks on deprecated Capybara.default_wait_time" do
+    allow(Capybara).to receive(:respond_to?).with(:default_max_wait_time).and_return(false)
+    expect(Capybara).to receive(:default_wait_time).at_least(:once)
+
+    TransactionalCapybara::AjaxHelpers.wait_for_ajax(page)
+  end
 end


### PR DESCRIPTION
First of all, thanks so much @iangreenleaf for this gem and your [article](http://technotes.iangreenleaf.com/posts/the-one-true-guide-to-database-transactions-with-capybara.html). It deserves to be much more popular!
I've been using database cleaner for a long time without even knowing there was a more simple way to use transactions even with a separate browser process.

Everything works fine, except there is a deprecation warning with Capybara >= 2.6.0. `Capybara.default_wait_time` has been deprecated in favor of `Capybara.default_max_wait_time`.
https://github.com/jnicklas/capybara/blob/master/History.md#version-260
https://github.com/jnicklas/capybara/pull/1502

Here's a PR to handle the deprecation.
