### PR TITLE
Connection pool and mutexes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    transactional_capybara (0.1.0)
+    transactional_capybara (0.2.0)
       capybara
+      connection_pool
 
 GEM
   remote: https://rubygems.org/
@@ -34,6 +35,7 @@ GEM
     childprocess (0.5.6)
       ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
+    connection_pool (2.2.0)
     diff-lcs (1.2.5)
     ffi (1.9.10)
     i18n (0.7.0)
@@ -110,4 +112,4 @@ DEPENDENCIES
   transactional_capybara!
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/lib/transactional_capybara.rb
+++ b/lib/transactional_capybara.rb
@@ -1,3 +1,4 @@
 require "transactional_capybara/version"
 require "transactional_capybara/ajax_helpers"
 require "transactional_capybara/shared_connection"
+require "transactional_capybara/connection_mutexes"

--- a/lib/transactional_capybara/connection_mutexes.rb
+++ b/lib/transactional_capybara/connection_mutexes.rb
@@ -1,0 +1,21 @@
+module Mysql2ClientMutex
+  @@semaphore = Mutex.new
+
+  def query_with_lock(*args)
+    @@semaphore.synchronize { query_without_lock(*args) }
+  end
+
+  def self.prepended(base)
+    base.class_eval do
+      alias_method :query_without_lock, :query
+      alias_method :query, :query_with_lock
+    end
+  end
+end
+
+module TransactionalCapybara
+  module_function
+  def use_mutexes
+    Mysql2::Client.prepend(Mysql2ClientMutex) if defined?(Mysql2::Client) == 'constant'
+  end
+end

--- a/lib/transactional_capybara/rspec.rb
+++ b/lib/transactional_capybara/rspec.rb
@@ -2,6 +2,8 @@ require 'transactional_capybara'
 
 RSpec.configure do |config|
   TransactionalCapybara.share_connection
+  TransactionalCapybara.use_mutexes
+
   config.after(:each, js: true) do
     TransactionalCapybara::AjaxHelpers.wait_for_ajax(page)
   end

--- a/lib/transactional_capybara/shared_connection.rb
+++ b/lib/transactional_capybara/shared_connection.rb
@@ -1,9 +1,11 @@
+require 'connection_pool'
+
 class ActiveRecord::Base
   mattr_accessor :shared_connection
   @@shared_connection = nil
 
   def self.connection
-    @@shared_connection || retrieve_connection
+    @@shared_connection || ConnectionPool::Wrapper.new(size: 1) { retrieve_connection }
   end
 end
 

--- a/lib/transactional_capybara/version.rb
+++ b/lib/transactional_capybara/version.rb
@@ -1,3 +1,3 @@
 module TransactionalCapybara
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/transactional_capybara.gemspec
+++ b/transactional_capybara.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capybara"
+  spec.add_dependency "connection_pool"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/transactional_capybara.gemspec
+++ b/transactional_capybara.gemspec
@@ -6,8 +6,8 @@ require 'transactional_capybara/version'
 Gem::Specification.new do |spec|
   spec.name          = "transactional_capybara"
   spec.version       = TransactionalCapybara::VERSION
-  spec.authors       = ["Ian Young"]
-  spec.email         = ["ian@iangreenleaf.com"]
+  spec.authors       = ["Ian Young", "Igor Suleymanov"]
+  spec.email         = ["ian@iangreenleaf.com", "igorsuleymanoff@gmail.com"]
   spec.description   = %q{Support for DB transactions with Capybara}
   spec.summary       = %q{Speed up your test suite with database transactions, without losing your mind to Capybara connection problems. Supports shared connections, plus AJAX watchers to avoid common deadlock scenarios.}
   spec.homepage      = ""


### PR DESCRIPTION
### Use connection_pool gem to prevent concurrent access

Using connection pool helps in preventing the application code from
accessing database connection concurrently.

However this will not prevent scenarios when same connection is used
to concurrently query the database.

Borrowed from https://gist.github.com/josevalim/470808#gistcomment-474499

### Use mutex to prevent concurrent access to the connection

Currently this is only implemented for MySQL client, however it's easy
to implement similar solution for other DB clients.

Wrap `Mysql2::Client#query` with a mutex to prevent concurrent access,
which results in exceptions.

Borrowed from https://gist.github.com/josevalim/470808#gistcomment-1280898